### PR TITLE
Remove redundant clones to fix warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,7 +197,7 @@ impl ProcessedConfig {
             if i == 0 {
                 if let Some(prefix) = key_decor.prefix() {
                     if !prefix.is_empty() {
-                        section_decor.set_prefix(prefix.clone());
+                        section_decor.set_prefix(prefix);
                         key_decor.set_prefix("".to_string());
                     }
                 }
@@ -225,7 +225,7 @@ impl ProcessedConfig {
                     // Cleanup for next sections.
                     section = Vec::new();
                     section_decor = Decor::default();
-                    section_decor.set_prefix(prefix.clone());
+                    section_decor.set_prefix(prefix);
                     key_decor.set_prefix("".to_string());
                 }
             }


### PR DESCRIPTION
Removing redundant clones fixes `noop_method_call` warning:
```
error: call to `.clone()` on a reference in this situation does nothing
Error:    --> src/lib.rs:200:56
200 |                         section_decor.set_prefix(prefix.clone());
    |                                                        ^^^^^^^^ help: remove this redundant call
    = note: the type `str` does not implement `Clone`, so calling `clone` on `&str` copies the reference, which does not do anything and can be removed
    = note: `-D noop-method-call` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(noop_method_call)]`
error: call to `.clone()` on a reference in this situation does nothing
Error:    --> src/lib.rs:228:52
228 |                     section_decor.set_prefix(prefix.clone());
    |                                                    ^^^^^^^^ help: remove this redundant call
    = note: the type `str` does not implement `Clone`, so calling `clone` on `&str` copies the reference, which does not do anything and can be removed
```